### PR TITLE
VCST-4328: Update to .NET10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.802.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix>
     </VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>

--- a/src/VirtoCommerce.SeqLog.Core/VirtoCommerce.SeqLog.Core.csproj
+++ b/src/VirtoCommerce.SeqLog.Core/VirtoCommerce.SeqLog.Core.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Seq.Extensions.Logging" Version="6.1.0" />
+    
+    <PackageReference Include="Seq.Extensions.Logging" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.SeqLog.Web/VirtoCommerce.SeqLog.Web.csproj
+++ b/src/VirtoCommerce.SeqLog.Web/VirtoCommerce.SeqLog.Web.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
@@ -8,7 +8,7 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.800.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.SeqLog.Core\VirtoCommerce.SeqLog.Core.csproj" />

--- a/src/VirtoCommerce.SeqLog.Web/module.manifest
+++ b/src/VirtoCommerce.SeqLog.Web/module.manifest
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
   <id>VirtoCommerce.SeqLog</id>
-  <version>3.802.0</version>
+  <version>3.1000.0</version>
   <version-tag>
   </version-tag>
-  <platformVersion>3.800.0</platformVersion>
+  <platformVersion>3.1002.0</platformVersion>
   <dependencies>
   </dependencies>
   <title>SeqLog</title>
@@ -21,7 +21,7 @@
   <assemblyFile>VirtoCommerce.SeqLog.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.SeqLog.Web.Module, VirtoCommerce.SeqLog.Web</moduleType>
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2011-2024 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2014-2026 Virto Commerce. All rights reserved</copyright>
   <tags>extension module</tags>
   <groups>
   </groups>

--- a/tests/VirtoCommerce.SeqLog.Tests/VirtoCommerce.SeqLog.Tests.csproj
+++ b/tests/VirtoCommerce.SeqLog.Tests/VirtoCommerce.SeqLog.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
@@ -8,13 +8,13 @@
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.SeqLog.Core\VirtoCommerce.SeqLog.Core.csproj" />


### PR DESCRIPTION
## Description
feat: Update to .NET10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.SeqLog_3.1000.0-pr-2-9e9c.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises runtime and dependency baselines (.NET `net10.0`, Seq/Serilog packages, Platform.Core, and test tooling), which can introduce compatibility/build issues across consumers and CI.
> 
> **Overview**
> Upgrades the module (core, web, and tests) from `.NET 8` to `net10.0` and bumps the module version to `3.1000.0`.
> 
> Updates key dependencies to match the new baseline: `VirtoCommerce.Platform.Core` to `3.1002.0`, `Seq.Extensions.Logging`/`Serilog.Sinks.Seq` to `9.0.0`, and test tooling to newer `coverlet`, `Microsoft.NET.Test.Sdk`, and `xunit.v3`. Also refreshes `module.manifest` metadata (platform version and copyright).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e9c4b277f35427135d9030e26b21dad576e6cb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->